### PR TITLE
Support Rails 5

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -6,11 +6,12 @@ h3. Authors
 
 * "Paul Gross":http://www.prgs.net
 * "Jesse Newland":http://jnewland.com
+* "Josh Nichols":http://technicalpickles.com
 
 h2. Requirements
 
 * Rails
-* MySQL, Postgres, or Oracle. sqlite not supported, sorry.
+* MySQL, Postgres, or sqlite
 
 h2. Installation
 
@@ -28,7 +29,9 @@ In your @config/routes.rb@:
 
 <pre>
   <code>
-    pulse '/my/pulse/url'
+    pulse
+    # or customize the URL
+    pulse '/admin/pulse'
   </code>
 </pre>
 
@@ -56,7 +59,9 @@ Finally, add a route to config/routes.rb:
 
 <pre>
   <code>
-    map.pulse 'pulse'
+    map.pulse
+    # or customize the URL
+    map.pulse '/admin/pulse'
   </code>
 </pre>
 

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,2 @@
-require File.dirname(__FILE__) + "/lib/rails-pulse"
+$LOAD_PATH.unshift File.dirname(__FILE__) + "/lib"
+require 'rails-pulse'

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -8,7 +8,10 @@ class PulseController < ActionController::Base
     adapter = ActiveRecord::Base::connection_pool.spec.config[:adapter]
 
     health_method = "#{adapter}_healthy?"
-    activerecord_okay = if respond_to?(health_method)
+
+    # Need to include all methods in respond_to? because Ruby 2.0 returns false
+    # even for protected methods.
+    activerecord_okay = if respond_to?(health_method, true)
                           send(health_method)
                         else
                           raise "Don't know how to check #{adapter}... please to fix?"

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -22,6 +22,8 @@ class PulseController < ActionController::Base
     end
   end
 
+  protected 
+
   #cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
   def logger
     nil

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -43,6 +43,8 @@ class PulseController < ActionController::Base
   def postgresql_healthy?
     select_one_count == 1
   end
+  
+  alias_method :postgis_healthy?, :postgresql_health?
 
   def select_one_count
     count = begin

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 class PulseController < ActionController::Base
   session :off unless Rails::VERSION::STRING >= "2.3"
 
@@ -26,9 +27,8 @@ class PulseController < ActionController::Base
 
   protected 
 
-  # cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
   def logger
-    nil
+    OpenStruct.new
   end
 
   def sqlite3_healthy?

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -1,11 +1,10 @@
 class PulseController < ActionController::Base
   session :off unless Rails::VERSION::STRING >= "2.3"
 
-  #The pulse action. Runs <tt>select 1</tt> on the DB. If a sane result is
-  #returned, 'OK' is displayed and a 200 response code is returned. If not,
-  #'ERROR' is returned along with a 500 response code.
+  # The pulse action. Runs <tt>select 1</tt> on the DB. If a sane result is
+  # returned, 'OK' is displayed and a 200 response code is returned. If not,
+  # 'ERROR' is returned along with a 500 response code.
   def pulse
-
     adapter = ActiveRecord::Base::connection_pool.spec.config[:adapter]
 
     health_method = "#{adapter}_healthy?"
@@ -24,7 +23,7 @@ class PulseController < ActionController::Base
 
   protected 
 
-  #cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
+  # cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
   def logger
     nil
   end

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -5,18 +5,73 @@ class PulseController < ActionController::Base
   #returned, 'OK' is displayed and a 200 response code is returned. If not,
   #'ERROR' is returned along with a 500 response code.
   def pulse
-    if (ActiveRecord::Base::connection_pool.spec.adapter_method =~ /mysql2/) &&
-      ((ActiveRecord::Base.connection.execute("select 1 from dual").count rescue 0) == 1)
-      render :text => "<html><body>OK  #{Time.now.utc.to_s(:db)}</body></html>"
-    elsif (ActiveRecord::Base.connection.execute("select 1 from dual").num_rows rescue 0) == 1
-      render :text => "<html><body>OK  #{Time.now.utc.to_s(:db)}</body></html>"
+
+    adapter = ActiveRecord::Base::connection_pool.spec.config[:adapter]
+
+    health_method = "#{adapter}_healthy?"
+    activerecord_okay = if respond_to?(health_method)
+                          send(health_method)
+                        else
+                          raise "Don't know how to check #{adapter}... please to fix?"
+                        end
+
+    if activerecord_okay
+      render :text => okay_response
     else
-      render :text => '<html><body>ERROR</body></html>', :status => :internal_server_error
+      render :text => error_response, :status => :internal_server_error
     end
   end
 
   #cancel out loggin for the PulseController by defining logger as <tt>nil</tt>
   def logger
     nil
+  end
+
+  def sqlite3_healthy?
+    select_one_count == 1
+  end
+
+  def mysql_healthy?
+    select_one_from_dual_num_rows == 1
+  end
+
+  def mysql2_healthy?
+    select_one_from_dual_count == 1
+  end
+
+  def postgresql_healthy?
+    select_one_count == 1
+  end
+
+  def select_one_count
+    count = begin
+              ActiveRecord::Base.connection.execute("select 1").count
+            rescue
+              0
+            end
+  end
+
+  def select_one_from_dual_count
+    begin
+      ActiveRecord::Base.connection.execute("select 1 from dual").count
+    rescue
+      0
+    end
+  end
+
+  def select_one_from_dual_num_rows
+    begin
+      ActiveRecord::Base.connection.execute("select 1 from dual").num_rows
+    rescue
+      0
+    end
+  end
+
+  def okay_response
+    "<html><body>OK  #{Time.now.utc.to_s(:db)}</body></html>"
+  end
+
+  def error_response
+    '<html><body>ERROR</body></html>'   
   end
 end

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -19,9 +19,10 @@ class PulseController < ActionController::Base
                         end
 
     if activerecord_okay
-      render :text => okay_response
+      render response_for_rails_version(Rails::VERSION::STRING, okay_response)
     else
-      render :text => error_response, :status => :internal_server_error
+      render response_for_rails_version(Rails::VERSION::STRING, error_response).
+        merge(:status => :internal_server_error)
     end
   end
 
@@ -78,6 +79,14 @@ class PulseController < ActionController::Base
   end
 
   def error_response
-    '<html><body>ERROR</body></html>'   
+    '<html><body>ERROR</body></html>'
+  end
+
+  def response_for_rails_version(rails_version_string, response)
+    if rails_version_string >= "4.1"
+      { :html => response.html_safe }
+    else
+      { :text => response }
+    end
   end
 end

--- a/lib/pulse/controller.rb
+++ b/lib/pulse/controller.rb
@@ -44,7 +44,7 @@ class PulseController < ActionController::Base
     select_one_count == 1
   end
   
-  alias_method :postgis_healthy?, :postgresql_health?
+  alias_method :postgis_healthy?, :postgresql_healthy?
 
   def select_one_count
     count = begin

--- a/lib/pulse/helper.rb
+++ b/lib/pulse/helper.rb
@@ -1,2 +1,4 @@
+# some versions of Rails expect there to be a helper for each controller
+# soooo... fake it out
 module PulseHelper
 end

--- a/lib/pulse/routes.rb
+++ b/lib/pulse/routes.rb
@@ -1,6 +1,7 @@
 module Pulse
   module Routes
-    def pulse(path)
+    def pulse(path = nil)
+      path ||= "/pulse"
       if Rails::VERSION::MAJOR == 2
         connect path, :controller => 'pulse', :action => 'pulse'
       else

--- a/rails-pulse.gemspec
+++ b/rails-pulse.gemspec
@@ -20,5 +20,9 @@ Gem::Specification.new do |s|
   
   s.add_runtime_dependency "rails"
 
+  s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "multi_rails"
+
   s.rubygems_version = %q{1.2.0}
 end

--- a/rails-pulse.gemspec
+++ b/rails-pulse.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{rails-pulse}
-  s.version = "0.5.0"
+  s.version = "0.5.1"
   s.authors = ["Paul Gross", "Jesse Newland", "Josh Goebel", "Will Farrington", "Josh Nichols"]
   s.date = %q{2013-04-01}
   s.description = s.summary = %q{Adds a pulse URL that pings the DB to a Rails app.}

--- a/rails-pulse.gemspec
+++ b/rails-pulse.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name = %q{rails-pulse}
-  s.version = "0.4.7"
-  s.authors = ["Paul Gross", "Jesse Newland", "Josh Goebel", "Will Farrington"]
-  s.date = %q{2012-01-10}
+  s.version = "0.5.0"
+  s.authors = ["Paul Gross", "Jesse Newland", "Josh Goebel", "Will Farrington", "Josh Nichols"]
+  s.date = %q{2013-04-01}
   s.description = s.summary = %q{Adds a pulse URL that pings the DB to a Rails app.}
   s.description += "\nThis is the maintained version of the `pulse` gem."
   s.email = %q{jnewland@gmail.com}


### PR DESCRIPTION
### Bring up to date with https://github.com/jnewland/pulse
I forked from the upstream repo, and therefore this PR includes commits from its master branch that are ahead of master here in the railsmachine repo. I assume we want those updates.

### Rails 5 Support
- After upgrading to Rails 5, the pulse controller errors on calls to logger.info?. Pulse was defining logger as nil. By using an OpenStruct calls of logger methods will not error, but it will log nothing as intended.
- render :text is deprecated. Replace with render :html for Rails versions >= 4.1.
Reference: http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#rendering-content-from-string

I considered bumping the gem version, but I wasn't sure of the versioning process for this gem so I figured I'd leave that to the maintainers. Happy to add a version bump if desired.

Also the test suite depends on the multi_rails gem, but it appears to be out of date. I got an error in the Rakefile, line 2, where it executes require 'load_multi_rails_rake_tasks'. If you have any guidance on how to proceed with testing I'll add specs.