### PR TITLE
Update readme to reflect supported Rails versions

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -15,7 +15,7 @@ h2. Requirements
 
 h2. Installation
 
-h3. Rails 3.x
+h3. Rails 3.x – 5.x
 
 Just add the gem to your @Gemfile@ and then @bundle install@:
 


### PR DESCRIPTION
Update readme to show that Rails 5.x is supported. This helps readers understand at a glance that this fork of pulse is being maintained.